### PR TITLE
Display instructions for manifest configuration in shield template

### DIFF
--- a/shield/hooks/post_gen_project.py
+++ b/shield/hooks/post_gen_project.py
@@ -34,6 +34,14 @@ def main():
         SUCCESS + "Project generated in `{{ cookiecutter.project_slug }}`" + TERMINATOR
     )
 
+    print("Add these lines to your manifest file:")
+    print(
+        f"- name: {{cookiecutter.project_slug}}\n"
+        f"    repo-path: zephyr_{{cookiecutter.project_slug}}\n"
+        f"    revision: main\n"
+        f"    path: 6tron/shields/{{cookiecutter.project_slug}}\n"
+    )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The following lines are displayed after shield generation:

```
Add these lines to your manifest file:
- name: zest_example
    repo-path: zephyr_zest_example
    revision: main
    path: 6tron/drivers/zest_example
```