### PR TITLE
Moved zephyr_library() upward

### DIFF
--- a/sensor/{{cookiecutter.project_slug}}/CMakeLists.txt
+++ b/sensor/{{cookiecutter.project_slug}}/CMakeLists.txt
@@ -1,4 +1,6 @@
 # Copyright (c) {{cookiecutter.copyright_year}} {{cookiecutter.copyright_holder}}
 # SPDX-License-Identifier: Apache-2.0
 
+zephyr_library()
+
 add_subdirectory(drivers)

--- a/sensor/{{cookiecutter.project_slug}}/drivers/sensor/{{cookiecutter.vendor_prefix}}/{{cookiecutter.__reference_snake}}/CMakeLists.txt
+++ b/sensor/{{cookiecutter.project_slug}}/drivers/sensor/{{cookiecutter.vendor_prefix}}/{{cookiecutter.__reference_snake}}/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Copyright (c) {{cookiecutter.copyright_year}} {{cookiecutter.copyright_holder}}
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-
 zephyr_library_sources({{cookiecutter.__reference_snake}}.c)


### PR DESCRIPTION
Move `zephyr_lybrary()` upward to create a zephyr library at the top of the driver.
This allow sharing private headers between APIs of the drivers thanks to `zephyr_library_include_directories(DIR_TO_PRIVATELY_SHARE)`