### PR TITLE
56 add a sixtron bus overlay to the driver template

### DIFF
--- a/sensor/cookiecutter.json
+++ b/sensor/cookiecutter.json
@@ -6,6 +6,7 @@
     "__reference_snake": "{{ cookiecutter.reference|lower|replace(' ', '-')|replace('-', '_') }}",
     "__reference_dash": "{{cookiecutter.__reference_snake|replace('_','-')}}",
     "sensor_type": "TYPE",
+    "__reference_type": "{{ cookiecutter.sensor_type|lower|replace(' ', '-')|replace('-', '_') }}",
     "bus": [
         "I2C",
         "SPI",

--- a/sensor/{{cookiecutter.project_slug}}/samples/README.md
+++ b/sensor/{{cookiecutter.project_slug}}/samples/README.md
@@ -1,0 +1,46 @@
+# Overview
+
+This sample application provides an example usage of the {{cookiecutter.vendor}} {{cookiecutter.reference}} {{cookiecutter.sensor_type}}.
+
+> [!NOTE]
+>
+> Optional overview notes
+
+# Requirements
+
+- List of required elements
+
+> [!NOTE]
+>
+> Optional requirement notes
+
+# References
+
+- [{{cookiecutter.reference}} Component]().
+- [{{cookiecutter.reference}} Datasheet]().
+
+> [!NOTE]
+>
+> Optional reference notes
+
+# Building and Running
+
+```shell
+cd <{{cookiecutter.project_slug}}>
+west build -p always -b <BOARD> samples/ -- -D DTC_OVERLAY_FILE=sixtron_bus.overlay
+west flash
+```
+
+> [!NOTE]
+>
+> Optional building notes
+
+# Sample Output
+
+```shell
+*** Booting Zephyr OS build v3.7.0 ***
+
+# Fill with correct expected output
+
+<repeats endlessly>
+```

--- a/sensor/{{cookiecutter.project_slug}}/samples/sample.yaml
+++ b/sensor/{{cookiecutter.project_slug}}/samples/sample.yaml
@@ -5,4 +5,9 @@ tests:
     tags: sensor
     integration_platforms:
       - zest_core_stm32l4a6rg
-    depends_on: YOUR_TAG_HERE
+    depends_on:
+{% if cookiecutter.bus == "I2C" %}      - i2c
+{% elif cookiecutter.bus == "SPI" %}      - spi
+{% elif cookiecutter.bus == "uart" %}      - uart
+{% endif %}      - YOUR_TAG_HERE
+    extra_args: "DTC_OVERLAY_FILE=sixtron_bus.overlay"

--- a/sensor/{{cookiecutter.project_slug}}/samples/sixtron_bus.overlay
+++ b/sensor/{{cookiecutter.project_slug}}/samples/sixtron_bus.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) {{cookiecutter.copyright_year}}, {{cookiecutter.copyright_holder}}
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/sixtron-header.h>
+
+\ {
+    aliases {
+		{{cookiecutter.__reference_dash}} = &{{cookiecutter.__reference_dash}}_{{cookiecutter.__reference_type}};
+	};
+{% if cookiecutter.bus == "NONE" %}
+    {{cookiecutter.__reference_dash}}_{{cookiecutter.__reference_type}}: {{cookiecutter.__reference_snake}} {
+        compatible = "{{cookiecutter.vendor_prefix}},{{cookiecutter.__reference_dash}}";
+    };
+{% endif %}};
+{% if cookiecutter.bus != "NONE" %}{% if cookiecutter.bus == "I2C" %}
+&sixtron_i2c {
+    status = "okay";
+
+    {{cookiecutter.__reference_dash}}_{{cookiecutter.__reference_type}}: {{cookiecutter.__reference_snake}}@XX {
+        compatible = "{{cookiecutter.vendor_prefix}},{{cookiecutter.__reference_dash}}";
+        reg = <0xXX>;
+    };
+{% elif cookiecutter.bus == "SPI" %}
+&sixtron_spi {
+    status = "okay";
+
+    {{cookiecutter.__reference_dash}}_{{cookiecutter.__reference_type}}: {{cookiecutter.__reference_snake}}@X {
+        compatible = "{{cookiecutter.vendor_prefix}},{{cookiecutter.__reference_dash}}";
+        reg = <X>;
+    };
+{% elif cookiecutter.bus == "SERIAL" %}
+&sixtron_uart {
+    status = "okay";
+    current-speed = <9600>;
+
+    {{cookiecutter.__reference_dash}}_{{cookiecutter.__reference_type}}: {{cookiecutter.__reference_snake}} {
+        compatible = "{{cookiecutter.vendor_prefix}},{{cookiecutter.__reference_dash}}";
+    };
+{% endif %}};
+{% endif %}

--- a/sensor/{{cookiecutter.project_slug}}/samples/src/main.c
+++ b/sensor/{{cookiecutter.project_slug}}/samples/src/main.c
@@ -9,7 +9,7 @@
 
 int main(void)
 {
-	const struct device *const dev = DEVICE_DT_GET_ANY({{cookiecutter.vendor_prefix}}_{{cookiecutter.__reference_snake}});
+	const struct device *const dev = DEVICE_DT_GET(DT_ALIAS({{cookiecutter.__reference_dash}}));
 	struct sensor_value value;
 
 	if (!device_is_ready(dev)) {


### PR DESCRIPTION
- Created `sixtron_bus.overlay` in **samples/**, generation depends on bus type
- Created `README.md` in **samples/**
- Added **extra_args** to `sample.yaml`
- Updated **depends** in `samples.yaml` to support of bus type selected
- Changed device recovery for **DT_ALIAS(alias)** in `main.c`