### PR TITLE
Fix feature reference to devcontainers-extra in devcontainer configuration

### DIFF
--- a/workspace_application/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
+++ b/workspace_application/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "{{cookiecutter.application}}",
     "dockerFile": "Dockerfile",
     "features": {
-        "ghcr.io/devcontainers-contrib/features/pre-commit:2": {}
+        "ghcr.io/devcontainers-extra/features/pre-commit:2": {}
     },
     "runArgs": [
         "--privileged"


### PR DESCRIPTION
This pull request updates the feature sources in two configuration files for the development container setup, switching from `devcontainers-contrib` to `devcontainers-extra` ([Source](https://containers.dev/features)).

* [`workspace_application/{{cookiecutter.project_slug}}/.devcontainer/devcontainer.json`](diffhunk://#diff-fc414ef346541a0dce7c5b7aa7853243f5c707ed12334b08d1ade1259218ee30L5-R5): Updated the pre-commit feature source from `ghcr.io/devcontainers-contrib/features/pre-commit:2` to `ghcr.io/devcontainers-extra/features/pre-commit:2`.