### PR TITLE
Add support for secure application with STSafe configuration and cleanup

### DIFF
--- a/workspace_application/cookiecutter.json
+++ b/workspace_application/cookiecutter.json
@@ -2,6 +2,10 @@
     "application": "Example Application",
     "description": "Zephyr Example Application",
     "project_slug": "{{ cookiecutter.application|lower|replace(' ', '_') }}",
+    "secure_app": [
+        false,
+        true
+    ],
     "copyright_holder": "CATIE",
     "copyright_year": "{% now 'utc', '%Y' %}",
     "create_repository": [
@@ -9,12 +13,12 @@
         false
     ],
     "_copy_without_render": [
-        ".github/workflows/build.yaml"
     ],
     "__prompts__": {
         "application": "Application name",
         "description": "Description of the application",
         "project_slug": "Slug of the project",  
+        "secure_app": "Application with Zest_Security_SecureElement",
         "copyright_holder": "Copyright holder",
         "copyright_year": "Copyright year",
         "create_repository": "Initialize a git repository"

--- a/workspace_application/hooks/post_gen_project.py
+++ b/workspace_application/hooks/post_gen_project.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 
 TERMINATOR = "\x1b[0m"
@@ -26,9 +27,26 @@ def create_repository():
     git_commit()
 
 
+def cleanup_secure():
+    secure_files = [
+        'app/include/'
+    ]
+    project_dir = os.path.realpath(os.path.curdir)
+
+    for file in secure_files:
+        path = os.path.join(project_dir, file)
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        elif os.path.isfile(path):
+            os.remove(path)
+
+
 def main():
     if {{cookiecutter.create_repository}}:
         create_repository()
+
+    if not {{cookiecutter.secure_app}}:
+        cleanup_secure()
 
     print(
         SUCCESS + "Project generated in `{{ cookiecutter.project_slug }}`" + TERMINATOR

--- a/workspace_application/{{cookiecutter.project_slug}}/.github/workflows/build.yaml
+++ b/workspace_application/{{cookiecutter.project_slug}}/.github/workflows/build.yaml
@@ -13,10 +13,12 @@ jobs:
   zephyr-application:
     strategy:
       matrix:
-        application: [ "app" ]
+        application: ['app']
     uses: catie-aq/zephyr_workflows/.github/workflows/application.yml@main
     with:
-      application: ${{ matrix.application }}
-
+{% raw %}      application: ${{ matrix.application }}{% endraw %}
+{% if cookiecutter.secure_app|lower == "true" %}
+      board: "zest_core_nrf5340/nrf5340/cpuapp"
+{% endif %}
     secrets:
-      personal_access_token: ${{ secrets.PAT }}
+{% raw %}      personal_access_token: ${{ secrets.PAT }}{% endraw %}

--- a/workspace_application/{{cookiecutter.project_slug}}/README.md
+++ b/workspace_application/{{cookiecutter.project_slug}}/README.md
@@ -1,0 +1,13 @@
+# {{cookiecutter.application}}
+
+{% if cookiecutter.secure_app|lower == "true" -%}
+
+> [!WARNING]
+>
+> Depending on which resistor you’ve fitted on your Zest Security Secure Element, you must update `app.overlay` accordingly:
+>
+> - R3 (Default): `<&sixtron_connector DIO1 GPIO_ACTIVE_HIGH>;`
+> - R4: `<&sixtron_connector DIO6 GPIO_ACTIVE_HIGH>;`
+> - R5: `<&sixtron_connector DIO11 GPIO_ACTIVE_HIGH>;`
+
+{% endif -%}

--- a/workspace_application/{{cookiecutter.project_slug}}/app/CMakeLists.txt
+++ b/workspace_application/{{cookiecutter.project_slug}}/app/CMakeLists.txt
@@ -6,4 +6,9 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project({{cookiecutter.application|lower|replace(' ','_')}} LANGUAGES C)
 
-target_sources(app PRIVATE src/main.c)
+{% if cookiecutter.secure_app|lower == "true" -%}
+zephyr_include_directories(include)
+{% endif -%}
+
+file(GLOB_RECURSE app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/workspace_application/{{cookiecutter.project_slug}}/app/app.overlay
+++ b/workspace_application/{{cookiecutter.project_slug}}/app/app.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) {{cookiecutter.copyright_year}}, {{cookiecutter.copyright_holder}}
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/sixtron-header.h>
+
+{% if cookiecutter.secure_app|lower == "true" -%}
+/ {
+	zephyr,user {
+		stsafereset-gpios = <&sixtron_connector DIO1 GPIO_ACTIVE_HIGH>; // R3
+	};
+};
+
+&sixtron_i2c {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+};
+{% endif -%}

--- a/workspace_application/{{cookiecutter.project_slug}}/app/include/stse_conf.h
+++ b/workspace_application/{{cookiecutter.project_slug}}/app/include/stse_conf.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) {{cookiecutter.copyright_year}}, {{cookiecutter.copyright_holder}}
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef STSE_CONF_H
+#define STSE_CONF_H
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+
+#define STSE_CONF_STSAFE_A_SUPPORT
+
+#define STSE_USE_RSP_POLLING
+#define STSE_MAX_POLLING_RETRY      10
+#define STSE_FIRST_POLLING_INTERVAL 33
+#define STSE_POLLING_RETRY_INTERVAL 100
+
+#define ZEPHYR_USER_NODE DT_PATH(zephyr_user)
+extern const struct gpio_dt_spec stsafe_reset;
+
+#endif /* STSE_CONF_H */

--- a/workspace_application/{{cookiecutter.project_slug}}/app/prj.conf
+++ b/workspace_application/{{cookiecutter.project_slug}}/app/prj.conf
@@ -1,2 +1,11 @@
 # Copyright (c) {{cookiecutter.copyright_year}} {{cookiecutter.copyright_holder}}
 # SPDX-License-Identifier: Apache-2.0
+
+{% if cookiecutter.secure_app|lower == "true" -%}
+CONFIG_GPIO=y
+CONFIG_I2C=y
+
+CONFIG_MAIN_STACK_SIZE=4096
+
+CONFIG_LIB_STSELIB=y
+{% endif -%}

--- a/workspace_application/{{cookiecutter.project_slug}}/app/src/main.c
+++ b/workspace_application/{{cookiecutter.project_slug}}/app/src/main.c
@@ -5,8 +5,41 @@
 
 #include <zephyr/kernel.h>
 
+{% if cookiecutter.secure_app|lower == "true" -%}
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+
+#include "stselib.h"
+
+const struct gpio_dt_spec stsafe_reset = GPIO_DT_SPEC_GET(ZEPHYR_USER_NODE, stsafereset_gpios);
+{% endif -%}
+
 int main(void)
 {
+{% if cookiecutter.secure_app|lower == "true" -%}
+	int ret = STSE_OK;
+	if (!gpio_is_ready_dt(&stsafe_reset)) {
+		printk("STSafe reset GPIO is not ready!");
+		return -1;
+	}
+	if (gpio_pin_configure_dt(&stsafe_reset, GPIO_OUTPUT_ACTIVE) < 0) {
+		printk("Failed to configure STSafe reset GPIO!");
+		return -1;
+	}
+
+	#ifdef CONFIG_STSAFE_A110
+		stse_handler.device_type = STSAFE_A110;
+	#elif defined(CONFIG_STSAFE_A120)
+		stse_handler.device_type = STSAFE_A120;
+	#endif
+
+	ret = stse_init(&stse_handler);
+	if (ret != STSE_OK) {
+		printk("Failed to initialize STSafe handler: %d", ret);
+		return -1;
+	}
+{% endif -%}
+
 	while (1) {
 		printk("Alive\n");
 		k_sleep(K_MSEC(1000));

--- a/workspace_application/{{cookiecutter.project_slug}}/west.yml
+++ b/workspace_application/{{cookiecutter.project_slug}}/west.yml
@@ -44,3 +44,11 @@ manifest:
       revision: v4.2.0+202508
       path: 6tron/6tron_manifest
       import: true
+{% if cookiecutter.secure_app|lower == "true" -%}
+    - name: stselib-module
+      remote: catie-6tron
+      repo-path: zephyr_stselib-module
+      revision: v1.1.1
+      path: 6tron/stselib_module
+      submodules: true
+{% endif -%}


### PR DESCRIPTION
This pull request adds support for optionally generating a "secure" Zephyr application variant that integrates the Zest Security Secure Element. The changes introduce a new `secure_app` option to the template, conditionally include security-related files and configuration, and update the project setup and documentation accordingly.