### PR TITLE
Add full_name field to board configuration

### DIFF
--- a/core/{{cookiecutter.project_slug}}/boards/{{cookiecutter.__board_vendor_lower}}/{{cookiecutter.__board_name_lower}}/board.yml
+++ b/core/{{cookiecutter.project_slug}}/boards/{{cookiecutter.__board_vendor_lower}}/{{cookiecutter.__board_name_lower}}/board.yml
@@ -1,5 +1,6 @@
 board:
   name: {{cookiecutter.__board_name_lower_underscore}}
+  full_name: {{cookiecutter.board_name}}
   vendor: {{cookiecutter.__board_vendor_lower}}
   socs:
     - name: {{cookiecutter.__zephyr_board_soc_lower}}


### PR DESCRIPTION
This pull request makes a minor update to the board configuration by adding a `full_name` field to the board definition. This helps provide a more descriptive name for the board in the configuration.

* Added a `full_name` field to the board definition in `board.yml` to store the complete board name.